### PR TITLE
Fixed "Autosave folder doesn't exist." Error

### DIFF
--- a/Effector-3.6.lua
+++ b/Effector-3.6.lua
@@ -211,13 +211,13 @@
 		if line.i == 1 then	--Autosave
 			local file_maxn = 512
 			local file_nmfx = format( "AutoSave_KE_%s", (count_save - 1) % file_maxn + 1 )
-			local file_name = format( "%sautosave\\Effector AutoSave %s.lua", aegisub.decode_path( "?user/" ), (count_save - 1) % file_maxn + 1 )
+			local file_name = format( "%s\\autosave\\Effector AutoSave %s.lua", aegisub.decode_path( "?user/" ), (count_save - 1) % file_maxn + 1 )
 			local file_save, infile_fx
 			file_save = io.open( file_name, "w" )
 			if file_save == nil then --> autosave folder nil
 				error(
 					format( "\n\n\n[::error -> autosave folder nil::]\nLa carpeta autosave no existe. Debes crear una carpeta con el nombre <<autosave>> en la dirección %s para que el Kara Effector se pueda ejecutar de forma correcta.\n\nLa siguiente carpeta debe existir:\n%s\\autosave\n\n\n",
-						aegisub.decode_path( "?data" ), aegisub.decode_path( "?data" )
+						aegisub.decode_path( "?user" ), aegisub.decode_path( "?user" )
 					), 2
 				)
 			end


### PR DESCRIPTION
So, as you can see, I wrote a solution for the error: '"Autosave folder does not exist / not found'". The issue actually came down to two things:

First, the folder only gets created after you've worked in Aegisub for a while, so that a few temp files are generated from your own work. The correct path for it is:

> "%APPDATA%\Aegisub\autosave"

Now, in the code it was originally written like this:

> "%sautosave"

Which basically translates to:

> "Aegisubautosave"

So I added two backslashes after `%s` to turn it into the correct path:

> "%s\autosave"

-->

> "Aegisub\autosave"

Then I changed two 'data' values to 'user' because otherwise the KE would look for the autosave folder inside the program's installation directory, which isn't what we want.

That’s everything I did and changed.